### PR TITLE
userProfileInfo 엔드포인트 서비스 추가했습니다

### DIFF
--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/config/SecurityConfig.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                 //== URL별 권한 관리 옵션==//
                 .authorizeHttpRequests()
                 .requestMatchers("/","/oauth2/**","/css/**", "/images/**", "/js/**").permitAll()
-                .requestMatchers("/test/**","api/v1/signup","/api/v1/profile","/api/v1/movies").permitAll() // 회원가입 접근 가능, 리다이렉용
+                .requestMatchers("/test/**","/signup","/userProfileInfo","/movies").permitAll() // 회원가입 접근 가능, 리다이렉용
                 .anyRequest().authenticated()// 인증필터를 거치지 않고 인가 처리를 해준다(이미 인증된 사용자로 처리했기에 인가 처리 해주는 것임)
                 .and()
                 //== 소셜 로그인 설정 ==//

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/user/UserController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/user/UserController.java
@@ -3,24 +3,44 @@ package com.ItsTime.ItNovation.controller.user;
 import com.ItsTime.ItNovation.common.dto.ApiResult;
 import com.ItsTime.ItNovation.domain.user.dto.SignUpRequestDto;
 import com.ItsTime.ItNovation.domain.user.dto.SignUpResponseDto;
+import com.ItsTime.ItNovation.domain.user.dto.UserProfileDto;
+import com.ItsTime.ItNovation.jwt.service.JwtService;
+import com.ItsTime.ItNovation.service.user.UserProfileService;
 import com.ItsTime.ItNovation.service.user.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Slf4j
 @RestController
-@RequestMapping("/api/v1")
 public class UserController {
     private final UserService userService;
+    private final UserProfileService userProfileService;
+    private final JwtService jwtService;
 
     @PostMapping("/signup")
-    public ResponseEntity<SignUpResponseDto> signup(@RequestBody SignUpRequestDto signUpRequestDto) {
+    public ResponseEntity<?> signup(@RequestBody SignUpRequestDto signUpRequestDto) {
+        log.info("회원가입");
         return userService.join(signUpRequestDto);
     }
 
+    @PostMapping("/userProfileInfo")
+    public ResponseEntity userProfile(@RequestBody UserProfileDto userProfileDto, HttpServletRequest request) {
+        Optional<String> accessToken = jwtService.extractAccessToken(request);
+
+        if(accessToken.isEmpty()){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }else{
+            return userProfileService.userProfile(userProfileDto, accessToken.get());
+        }
+    }
     @GetMapping("/profile")
     public String secondSignup() {
         return "리다이렉트";

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/UserProfileDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/UserProfileDto.java
@@ -1,0 +1,20 @@
+package com.ItsTime.ItNovation.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+
+@Getter
+@ToString
+public class UserProfileDto {
+    private final String nickname;
+    private final String introduction;
+
+    @Builder
+    public UserProfileDto(String nickname, String introduction) {
+        this.nickname = nickname;
+        this.introduction = introduction;
+    }
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * 커스텀 JSON 필터에서도 AbstractAuthenticationProcessingFilter를 상속받아 구현
  */
 public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
-    private static final String DEFAULT_LOGIN_REQUEST_URL = "/api/v1/login"; // "/login"으로 오는 요청을 처리
+    private static final String DEFAULT_LOGIN_REQUEST_URL = "/login"; // "/login"으로 오는 요청을 처리
     private static final String HTTP_METHOD = "POST"; // 로그인 HTTP 메소드는 POST
     private static final String CONTENT_TYPE = "application/json"; // JSON 타입의 데이터로 오는 로그인 요청만 처리
     private static final String USERNAME_KEY = "email"; // 회원 로그인 시 이메일 요청 JSON Key : "email"

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/user/UserProfileService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/user/UserProfileService.java
@@ -1,0 +1,45 @@
+package com.ItsTime.ItNovation.service.user;
+
+import com.ItsTime.ItNovation.domain.user.User;
+import com.ItsTime.ItNovation.domain.user.UserRepository;
+import com.ItsTime.ItNovation.domain.user.dto.UserProfileDto;
+import com.ItsTime.ItNovation.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+
+public class UserProfileService {
+
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    @Transactional
+    public ResponseEntity userProfile(UserProfileDto userProfileDto, String token) {
+        try{
+            log.info(token);
+            String email=jwtService.extractEmail(token).orElseThrow(() -> new IllegalArgumentException("유효하지 않은 토큰입니다."));
+
+            User user = userRepository.findByEmail(email)
+                    .orElseThrow(() -> new IllegalArgumentException("일치하는 회원이 없습니다."));
+
+            // 프로필 정보 업데이트
+            user.update(userProfileDto.getNickname(), userProfileDto.getIntroduction());
+            // 사용자 저장
+            userRepository.saveAndFlush(user);
+            return ResponseEntity.ok(null);
+        }catch (IllegalArgumentException e) {
+            //TODO: 세부적으로 HttpStatus 설정해보기
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+
+
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/user/UserService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/user/UserService.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 @RequiredArgsConstructor //final 붙은 필드에 대해 생성자 생성
 @Slf4j
 @Service
-
 public class UserService {
 
     private final UserRepository userRepository;
@@ -30,29 +29,30 @@ public class UserService {
 
 
     @Transactional
-    public ResponseEntity<SignUpResponseDto> join(SignUpRequestDto signUpRequestDto) {
+    public ResponseEntity<?> join(SignUpRequestDto signUpRequestDto) {
+        log.info("회원가입");
         String result = validateDuplicateUser(signUpRequestDto);
-        SignUpResponseDto signUpResponseDto=SignUpResponseDto.builder().userId(null).build();
         log.info(result);
         if (StringUtils.hasText(result)) {
 
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(signUpResponseDto); //wrapper 타입만 null 이 들어갈 수 있음
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+                     //wrapper 타입만 null 이 들어갈 수 있음
         } else {
             User user = User.builder()
                     .email(signUpRequestDto.getEmail())
                     .password(signUpRequestDto.getPassword())
-                    .role(Role.GUEST) //TODO: 두번째 로그인 진행해야함. 소개글과 별명 입력하면 Role.GUEST로 권한 변경됨
+                    .role(Role.GUEST)
                     .build();
 
             user.passwordEncode(passwordEncoder);
 
             userRepository.save(user);
             log.info(user.getEmail() + " 회원가입 성공");
-            return ResponseEntity.ok(SignUpResponseDto.builder().userId(user.getId()).build());
+            return ResponseEntity.ok(null);
         }
 
     }
+
 
     private String validateDuplicateUser(SignUpRequestDto signUpRequestDto) {
         Optional<User> findEmail = userRepository.findByEmail(signUpRequestDto.getEmail());
@@ -64,4 +64,6 @@ public class UserService {
         return errorMessage;
 
     }
+
+
 }

--- a/ItNovation/src/main/resources/application.yml
+++ b/ItNovation/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
/userProfileInfo 엔드포인트로 접속시
성공시 200, 실패시 400에러를 냅니다
Bearer xxx 형식으로 Authorization 헤더에 토큰을 넣은 채로 프론트엔드로 부터 해당 요청을 전송받으면 
jwtService의 extractAccessToken, extractEmail을 활용해 토큰을 추출 및 검증합니다.
만약 로그인 한 사용자가 맞다면, nickname과 Introduction을 정상적으로 입력받아 해당 사용자의 데이터베이스의 nickname, introduction 에 저장됩니다.

ps. 추가적으로 현재는 추출한 토큰의 이메일이 잘못된 경우와 해당 사용자가 존재하지 않는 경우 모드 400에러를 내지만, 시간이 난다면 세부적으로 http error 를 낼 계획입니다. 

궁금한거 있으면 댓글주세요