### PR TITLE
시큐리티 파일에서 permitAll 이 작동되지 않은 문제 해결

### DIFF
--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/config/SecurityConfig.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/config/SecurityConfig.java
@@ -31,6 +31,11 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import java.util.Arrays;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration
@@ -45,6 +50,10 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
 
+    List<RequestMatcher> specialUrlMatchers = Arrays.asList(
+            new AntPathRequestMatcher("/userProfile"),
+            new AntPathRequestMatcher("/login")
+    );
 
 
     //HttpSecurity 객체를 사용하여 Spring Security의 인증 및 권한 부여 규칙을 정의
@@ -76,6 +85,7 @@ public class SecurityConfig {
 
         //TODO: 필터 순서
         http.addFilterAfter(customJsonUsernamePasswordAuthenticationFilter(), LogoutFilter.class);
+        http.addFilterBefore(new SecurityFilter(), CustomJsonUsernamePasswordAuthenticationFilter.class);
         http.addFilterBefore(jwtAuthenticationProcessingFilter(), CustomJsonUsernamePasswordAuthenticationFilter.class);
         http.addFilterBefore(jwtExceptionFilter(), jwtAuthenticationProcessingFilter().getClass());
 
@@ -98,7 +108,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
-        JwtAuthenticationProcessingFilter jwtAuthenticationFilter = new JwtAuthenticationProcessingFilter(jwtService, userRepository);
+        JwtAuthenticationProcessingFilter jwtAuthenticationFilter = new JwtAuthenticationProcessingFilter(jwtService, userRepository,specialUrlMatchers);
         return jwtAuthenticationFilter;
     }
 

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/config/SecurityFilter.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/config/SecurityFilter.java
@@ -1,0 +1,30 @@
+package com.ItsTime.ItNovation.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SecurityFilter extends OncePerRequestFilter {
+
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info(request.getRequestURI());
+        filterChain.doFilter(request, response);
+    }
+
+
+
+}


### PR DESCRIPTION
permitall 이 작동하지 않아서 여러 해결법을 찾아보다가 
임의로 jwtAuthenticationProcessingFilter 해당 클래스에 인자로 Requestmatcher를 주어 이에 일치하는 url 인 경우 해당 필터를 통과하는 식으로 구현하였습니다. 

문제가 있으면 추후 수정하겠습니다