### PR TITLE
계속 되어지는 요청사항들에 대한 수정(패치노트 참고)

### DIFF
--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/review/ReviewController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/review/ReviewController.java
@@ -3,7 +3,12 @@ package com.ItsTime.ItNovation.controller.review;
 import com.ItsTime.ItNovation.domain.review.dto.ReviewPostRequestDto;
 import com.ItsTime.ItNovation.domain.review.dto.ReviewReadRequestDto;
 
+import com.ItsTime.ItNovation.domain.user.dto.LoginStateDto;
+import com.ItsTime.ItNovation.jwt.service.JwtService;
 import com.ItsTime.ItNovation.service.review.ReviewService;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final JwtService jwtService;
     @PostMapping
     public ResponseEntity reviewWrite(@RequestBody ReviewPostRequestDto reviewPostRequestDto, Authentication authentication) {
 
@@ -29,9 +35,16 @@ public class ReviewController {
     }
 
     @GetMapping("/Info/{reviewId}") // getMapping 으로 변경 -> id값 넘겨주기
-    public ResponseEntity reviewRead(@PathVariable Long reviewId){
-        return reviewService.reviewRead(reviewId);
+    public ResponseEntity reviewRead(@PathVariable Long reviewId, HttpServletRequest request){
+        Optional<String> s = jwtService.extractAccessToken(request);
+        if(s.isPresent()){
+            Optional<String> email = jwtService.extractEmail(s.get());
+            return reviewService.reviewRead(reviewId, email.get());
+        }
+        return reviewService.reviewRead(reviewId, null);
     }
+
+
 
 
     @GetMapping("/movieInfo/{movieId}")

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/review/ReviewController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/review/ReviewController.java
@@ -39,7 +39,9 @@ public class ReviewController {
         Optional<String> s = jwtService.extractAccessToken(request);
         if(s.isPresent()){
             Optional<String> email = jwtService.extractEmail(s.get());
-            return reviewService.reviewRead(reviewId, email.get());
+            if(email.isPresent()) {
+                return reviewService.reviewRead(reviewId, email.get());
+            }
         }
         return reviewService.reviewRead(reviewId, null);
     }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/singleMoviePage/SingleMoviePageController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/singleMoviePage/SingleMoviePageController.java
@@ -1,7 +1,10 @@
 package com.ItsTime.ItNovation.controller.singleMoviePage;
 
 
+import com.ItsTime.ItNovation.jwt.service.JwtService;
 import com.ItsTime.ItNovation.service.singleMoviePage.SingleMoviePageService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -18,11 +21,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class SingleMoviePageController {
 
     private final SingleMoviePageService singleMoviePageService;
+    private final JwtService jwtService;
 
     @GetMapping("/moviePage/{movieId}")
-    public ResponseEntity moviePage(@PathVariable Long movieId){
-        return singleMoviePageService.getReviewInformationAboutMovie(movieId);
+    public ResponseEntity moviePage(@PathVariable Long movieId, HttpServletRequest request){
+        Optional<String> s = jwtService.extractAccessToken(request);
+        if(s.isPresent()){
+            Optional<String> email = jwtService.extractEmail(s.get());
+            if(email.isPresent()) {
+                return singleMoviePageService.getReviewInformationAboutMovie(movieId, email.get());
+            }
+        }
+        log.info("로그인 상태가 아닙니다.");
+        return singleMoviePageService.getReviewInformationAboutMovie(movieId, null);
     }
+
+
 
 
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/topuser/TopUserController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/topuser/TopUserController.java
@@ -1,10 +1,14 @@
 package com.ItsTime.ItNovation.controller.topuser;
 
 
+import com.ItsTime.ItNovation.jwt.service.JwtService;
 import com.ItsTime.ItNovation.service.best.TodayBestUserService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,10 +18,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class TopUserController {
 
     private final TodayBestUserService todayBestUserService;
+    private final JwtService jwtService;
+
 
     @GetMapping("/today/topUser")
-    public ResponseEntity todayTopUser(){
-        return todayBestUserService.getBestUserInfo();
+    public ResponseEntity todayTopUser(HttpServletRequest request){
+
+        Optional<String> s = jwtService.extractAccessToken(request);
+        if(s.isPresent()){
+            Optional<String> email = jwtService.extractEmail(s.get());
+            if(email.isPresent()) {
+                return todayBestUserService.getBestUserInfo(email.get());
+            }
+        }
+        return todayBestUserService.getBestUserInfo(null);
     }
 
 

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/bestUser/TopUserResponseDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/bestUser/TopUserResponseDto.java
@@ -17,7 +17,7 @@ public class TopUserResponseDto {
     private String nickName;
     private String introduction;
     private Grade grade;
-    private int followers;
+    private Long followers;
     private Long followings;
     private Boolean isLoginedUserFollowsNowUser;
 
@@ -27,7 +27,7 @@ public class TopUserResponseDto {
 
     @Builder
     public TopUserResponseDto(Long userId, String profileImg, String nickName, String introduction,
-                              Grade grade, int followers, Long followings, List<TopUserReviewDto> reviews, Boolean isLoginedUserFollowsNowUser) {
+                              Grade grade, Long followers, Long followings, List<TopUserReviewDto> reviews, Boolean isLoginedUserFollowsNowUser) {
         this.userId = userId;
         this.profileImg = profileImg;
         this.nickName = nickName;

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/bestUser/TopUserResponseDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/bestUser/TopUserResponseDto.java
@@ -19,6 +19,7 @@ public class TopUserResponseDto {
     private Grade grade;
     private int followers;
     private Long followings;
+    private Boolean isLoginedUserFollowsNowUser;
 
 
 
@@ -26,7 +27,7 @@ public class TopUserResponseDto {
 
     @Builder
     public TopUserResponseDto(Long userId, String profileImg, String nickName, String introduction,
-                              Grade grade, int followers, Long followings, List<TopUserReviewDto> reviews) {
+                              Grade grade, int followers, Long followings, List<TopUserReviewDto> reviews, Boolean isLoginedUserFollowsNowUser) {
         this.userId = userId;
         this.profileImg = profileImg;
         this.nickName = nickName;
@@ -35,5 +36,6 @@ public class TopUserResponseDto {
         this.followers = followers;
         this.followings = followings;
         this.reviews = reviews;
+        this.isLoginedUserFollowsNowUser=isLoginedUserFollowsNowUser;
     }
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/follow/FollowRepository.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/follow/FollowRepository.java
@@ -26,6 +26,9 @@ public interface FollowRepository extends JpaRepository<FollowState, Long> {
     @Query("select count(*) from FollowState f where f.targetUser.id=:userId")
     Long countByFollowedUserId(@Param("userId") Long userId);
 
+    @Query("select count(*) from FollowState f where f.pushUser.id=:userId")
+    Long countByFollowingUserId(@Param("userId") Long userId);
+
     @Query("SELECT f.pushUser FROM FollowState f WHERE f.targetUser.id = :userId")
     List<User> findFollowersByUserId(@Param("userId") Long userId);
 

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/dto/SingleMoviePageMovieInfoDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/dto/SingleMoviePageMovieInfoDto.java
@@ -9,6 +9,7 @@ public class SingleMoviePageMovieInfoDto {
 
 
     private String movieImg;
+    private String movieBgImg;
     private String title;
     private String movieGenre;
     private String movieReleasedDate;
@@ -24,12 +25,13 @@ public class SingleMoviePageMovieInfoDto {
 
 
     @Builder
-    public SingleMoviePageMovieInfoDto(String movieImg, String title, String movieGenre,
+    public SingleMoviePageMovieInfoDto(String movieImg,String movieBgImg, String title, String movieGenre,
         String movieReleasedDate,
         Integer movieRunningTime, String movieActor, String movieDetail,
         MovieFeatureDto top3HasFeature,
         Integer movieLikeCount, Float avgStarScore, String movieDirector, String movieAge, String movieCountry) {
         this.movieImg = movieImg;
+        this.movieBgImg = movieBgImg;
         this.title = title;
         this.movieGenre = movieGenre;
         this.movieReleasedDate = movieReleasedDate;

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/dto/SingleMoviePageMovieInfoDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/dto/SingleMoviePageMovieInfoDto.java
@@ -17,6 +17,9 @@ public class SingleMoviePageMovieInfoDto {
     private String movieDetail;
     private MovieFeatureDto top3HasFeature;
     private Integer movieLikeCount;
+    private String movieDirector;
+    private String movieAge;
+    private String movieCountry;
     private Float avgStarScore;
 
 
@@ -25,7 +28,7 @@ public class SingleMoviePageMovieInfoDto {
         String movieReleasedDate,
         Integer movieRunningTime, String movieActor, String movieDetail,
         MovieFeatureDto top3HasFeature,
-        Integer movieLikeCount, Float avgStarScore) {
+        Integer movieLikeCount, Float avgStarScore, String movieDirector, String movieAge, String movieCountry) {
         this.movieImg = movieImg;
         this.title = title;
         this.movieGenre = movieGenre;
@@ -36,5 +39,8 @@ public class SingleMoviePageMovieInfoDto {
         this.top3HasFeature = top3HasFeature;
         this.movieLikeCount = movieLikeCount;
         this.avgStarScore = avgStarScore;
+        this.movieDirector = movieDirector;
+        this.movieAge = movieAge;
+        this.movieCountry = movieCountry;
     }
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/review/Review.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/review/Review.java
@@ -11,6 +11,7 @@ import lombok.*;
 
 import java.util.Date;
 import java.util.List;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/review/ReviewRepository.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/review/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.ItsTime.ItNovation.domain.review;
 
 import com.ItsTime.ItNovation.domain.movie.Movie;
+import com.ItsTime.ItNovation.domain.user.User;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findById(Long ReviewId);
 
 
+    Optional<Review> findByUser(User user);
 
     @Query("Select r from Review r where r.user.id=:userId order by r.createdDate desc")
     List<Review> findNewestReviewByUserId(@Param("userId") Long userId, Pageable pageable);
@@ -57,4 +59,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     int countHasGoodDiction(@Param("movie") Movie movie);
 
     Long countByMovieId(Long movieId);
+
+    Optional<Review> findByUserAndMovie(User user,Movie movie);
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/review/dto/ReviewReadResponseDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/review/dto/ReviewReadResponseDto.java
@@ -2,6 +2,7 @@ package com.ItsTime.ItNovation.domain.review.dto;
 
 
 import com.ItsTime.ItNovation.domain.movie.dto.ReviewMovieInfoDto;
+import com.ItsTime.ItNovation.domain.user.dto.ReviewLoginUserInfoDto;
 import com.ItsTime.ItNovation.domain.user.dto.ReviewUserInfoDto;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -15,13 +16,15 @@ public class ReviewReadResponseDto {
     private ReviewInfoDto review;
     private ReviewMovieInfoDto movie;
     private ReviewUserInfoDto user;
+    private ReviewLoginUserInfoDto loginUser;
 
 
     @Builder
     public ReviewReadResponseDto(ReviewInfoDto review, ReviewMovieInfoDto movie,
-        ReviewUserInfoDto user) {
+        ReviewUserInfoDto user, ReviewLoginUserInfoDto loginUser) {
         this.review = review;
         this.movie = movie;
         this.user = user;
+        this.loginUser = loginUser;
     }
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/reviewLike/ReviewLikeRepository.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/reviewLike/ReviewLikeRepository.java
@@ -45,4 +45,6 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
     @Query("select count(*) from ReviewLike rl where rl.review.reviewId=:reviewId and rl.reviewLike=true")
     int countReviewLikeByReviewId(@Param("reviewId") Long reviewId);
 
+    @Query("select rl.reviewLike from ReviewLike rl where rl.user = :user")
+    Boolean isUserLike(@Param("user") User user);
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/reviewLike/ReviewLikeRepository.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/reviewLike/ReviewLikeRepository.java
@@ -5,6 +5,7 @@ import com.ItsTime.ItNovation.domain.user.User;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import javax.swing.text.html.Option;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -45,6 +46,6 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
     @Query("select count(*) from ReviewLike rl where rl.review.reviewId=:reviewId and rl.reviewLike=true")
     int countReviewLikeByReviewId(@Param("reviewId") Long reviewId);
 
-    @Query("select rl.reviewLike from ReviewLike rl where rl.user = :user")
-    Boolean isUserLike(@Param("user") User user);
+    @Query("select rl.reviewLike from ReviewLike rl where rl.user = :user and rl.review = :review")
+    Optional<Boolean> isUserLike(@Param("user") User user, @Param("review") Review review);
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/singleMoviePage/SingleMoviePageResponseDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/singleMoviePage/SingleMoviePageResponseDto.java
@@ -1,6 +1,7 @@
 package com.ItsTime.ItNovation.domain.singleMoviePage;
 
 import com.ItsTime.ItNovation.domain.movie.dto.SingleMoviePageMovieInfoDto;
+import com.ItsTime.ItNovation.domain.user.dto.SingleMoviePageLoginUserInfoDto;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,13 +13,14 @@ public class SingleMoviePageResponseDto {
     private List<SingleMoviePageReviewAndUserDto> reviewAndUserInfoList;
 
     private SingleMoviePageMovieInfoDto movie;
+    private SingleMoviePageLoginUserInfoDto loginUserInfoDto;
 
 
     @Builder
-    public SingleMoviePageResponseDto(List<SingleMoviePageReviewAndUserDto> reviewAndUserInfoList, SingleMoviePageMovieInfoDto movie) {
+    public SingleMoviePageResponseDto(List<SingleMoviePageReviewAndUserDto> reviewAndUserInfoList, SingleMoviePageMovieInfoDto movie, SingleMoviePageLoginUserInfoDto loginUserInfoDto) {
         this.reviewAndUserInfoList = reviewAndUserInfoList;
         this.movie = movie;
-
+        this.loginUserInfoDto = loginUserInfoDto;
     }
 
 

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/Grade.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/Grade.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Grade {
     STANDARD("STANDARD"),
-    PREIMUM("PREMIUM"),
+    PREMIUM("PREMIUM"),
     VIP("VIP"),
     SPECIAL("SPECIAL");
 

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/Grade.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/Grade.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Grade {
     STANDARD("STANDARD"),
-    PREIMUM("PREIMUM"),
+    PREIMUM("PREMIUM"),
     VIP("VIP"),
     SPECIAL("SPECIAL");
 

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/LoginStateDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/LoginStateDto.java
@@ -4,7 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class LoginStateDto {
+public class
+LoginStateDto {
     private Boolean loginState;
     private Long userId;
     private String nickname;

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/ReviewLoginUserInfoDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/ReviewLoginUserInfoDto.java
@@ -1,0 +1,18 @@
+package com.ItsTime.ItNovation.domain.user.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReviewLoginUserInfoDto {
+
+    private Boolean pushedFollow;
+    private Boolean pushedReviewLike;
+
+    @Builder
+    public ReviewLoginUserInfoDto(Boolean pushedFollow, Boolean pushedReviewLike) {
+        this.pushedFollow = pushedFollow;
+        this.pushedReviewLike = pushedReviewLike;
+    }
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/ReviewUserInfoDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/ReviewUserInfoDto.java
@@ -14,6 +14,9 @@ public class ReviewUserInfoDto {
     private Grade grade;
     private String introduction;
     private String profileImg;
+    private Long folllowerNum;
+    private Long followingNum;
+    private Boolean hasReviewLike;
 
 //    followerNum:Long,
 //        "hasReviewLike":Boolean,  추후 해당 기능 추가 후 추가 예정
@@ -21,12 +24,15 @@ public class ReviewUserInfoDto {
 
     @Builder
     public ReviewUserInfoDto(Long userId, String bgImg, String nickname, Grade grade,
-        String introduction, String profileImg) {
+        String introduction, String profileImg, Long folllowerNum, Long followingNum, Boolean hasReviewLike) {
         this.userId = userId;
         this.bgImg = bgImg;
         this.nickname = nickname;
         this.grade = grade;
         this.introduction = introduction;
         this.profileImg = profileImg;
+        this.folllowerNum = folllowerNum;
+        this.followingNum = followingNum;
+        this.hasReviewLike=hasReviewLike;
     }
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/ReviewUserInfoDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/ReviewUserInfoDto.java
@@ -14,7 +14,7 @@ public class ReviewUserInfoDto {
     private Grade grade;
     private String introduction;
     private String profileImg;
-    private Long folllowerNum;
+    private Long followerNum;
     private Long followingNum;
     private Boolean hasReviewLike;
 
@@ -24,14 +24,14 @@ public class ReviewUserInfoDto {
 
     @Builder
     public ReviewUserInfoDto(Long userId, String bgImg, String nickname, Grade grade,
-        String introduction, String profileImg, Long folllowerNum, Long followingNum, Boolean hasReviewLike) {
+        String introduction, String profileImg, Long followerNum, Long followingNum, Boolean hasReviewLike) {
         this.userId = userId;
         this.bgImg = bgImg;
         this.nickname = nickname;
         this.grade = grade;
         this.introduction = introduction;
         this.profileImg = profileImg;
-        this.folllowerNum = folllowerNum;
+        this.followerNum = followerNum;
         this.followingNum = followingNum;
         this.hasReviewLike=hasReviewLike;
     }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/SingleMoviePageLoginUserInfoDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/dto/SingleMoviePageLoginUserInfoDto.java
@@ -1,0 +1,21 @@
+package com.ItsTime.ItNovation.domain.user.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SingleMoviePageLoginUserInfoDto {
+
+    private Float reviewStar;
+    private Float movieStar;
+    private Boolean pushedMovieLike;
+
+
+    @Builder
+    public SingleMoviePageLoginUserInfoDto(Float reviewStar,Float movieStar, Boolean pushedMovieLike) {
+        this.reviewStar = reviewStar;
+        this.movieStar = movieStar;
+        this.pushedMovieLike=pushedMovieLike;
+    }
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/best/TodayBestUserService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/best/TodayBestUserService.java
@@ -65,15 +65,15 @@ public class TodayBestUserService {
 
     private void madeInternalResponseDto(List<TopUserReviewDto> topUserReviewDtos,
         List<TopUserResponseDto> top5UserResponseDtos, User user, User loginUser) {
-        int followers = user.getFollowStates().size();
+        Long following = (long) user.getFollowStates().size();
         log.info(yesterday.toString());
-        Long following = followRepository.countByFollowedUserId(user.getId());
+        Long followers = followRepository.countByFollowedUserId(user.getId());
         List<Review> reviews = reviewLikeRepository.bestReviewsByUserId(yesterday, user.getId());
         addBestReview(topUserReviewDtos, reviews);
         Pageable remainPageable = PageRequest.of(0, 2);
         addNewestReview(topUserReviewDtos, user, remainPageable);
         TopUserResponseDto topUserResponseDto = buildTopUserResponseDto(
-            topUserReviewDtos, user, followers, following, loginUser);
+            topUserReviewDtos, user, following, followers, loginUser);
         top5UserResponseDtos.add(topUserResponseDto);
     }
 
@@ -99,7 +99,7 @@ public class TodayBestUserService {
     }
 
     private TopUserResponseDto buildTopUserResponseDto(
-        List<TopUserReviewDto> topUserReviewDtos, User user, int followers, Long following, User loginUser) {
+        List<TopUserReviewDto> topUserReviewDtos, User user, Long following, Long followers, User loginUser) {
         TopUserResponseDto topUserResponseDto = TopUserResponseDto.builder()
             .userId(user.getId())
             .profileImg(user.getProfileImg())

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/best/TodayBestUserService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/best/TodayBestUserService.java
@@ -2,6 +2,7 @@ package com.ItsTime.ItNovation.service.best;
 
 import com.ItsTime.ItNovation.domain.bestUser.TopUserResponseDto;
 import com.ItsTime.ItNovation.domain.follow.FollowRepository;
+import com.ItsTime.ItNovation.domain.follow.FollowState;
 import com.ItsTime.ItNovation.domain.movie.Movie;
 import com.ItsTime.ItNovation.domain.movie.dto.TopUserMovieDto;
 import com.ItsTime.ItNovation.domain.review.Review;
@@ -9,9 +10,11 @@ import com.ItsTime.ItNovation.domain.review.ReviewRepository;
 import com.ItsTime.ItNovation.domain.review.dto.TopUserReviewDto;
 import com.ItsTime.ItNovation.domain.reviewLike.ReviewLikeRepository;
 import com.ItsTime.ItNovation.domain.user.User;
+import com.ItsTime.ItNovation.domain.user.UserRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +32,7 @@ public class TodayBestUserService {
     private final ReviewLikeRepository reviewLikeRepository;
     private final ReviewRepository reviewRepository;
     private final FollowRepository followRepository;
+    private final UserRepository userRepository;
 
     private final LocalDate yesterday = LocalDate.now().minusDays(1);
 
@@ -37,24 +41,30 @@ public class TodayBestUserService {
      * @return
      */
     @Transactional
-    public ResponseEntity getBestUserInfo() {
+    public ResponseEntity getBestUserInfo(String email) {
         Pageable pageable = PageRequest.of(0, 5);
         List<User> top5UsersWithTodayDate = reviewLikeRepository.findTopUsersWithYesterdayDate(yesterday,
             pageable); // -> 이거 전날 기준으로 고쳐야 함!
         System.out.println("top5UsersWithTodayDate = " + top5UsersWithTodayDate);
 
         List<TopUserResponseDto> top5UserResponseDtos = new ArrayList<>();
+        User loginUser = null;
+        Optional<User> findUser = userRepository.findByEmail(email);
+
+        if(findUser.isPresent()){
+            loginUser=findUser.get();
+        }
 
         for (int index = 0; index < top5UsersWithTodayDate.size(); index++) {
             List<TopUserReviewDto> topUserReviewDtos = new ArrayList<>();
             User user = top5UsersWithTodayDate.get(index);
-            madeInternalResponseDto(topUserReviewDtos, top5UserResponseDtos, user);
+            madeInternalResponseDto(topUserReviewDtos, top5UserResponseDtos, user, loginUser);
         }
         return ResponseEntity.status(200).body(top5UserResponseDtos);
     }
 
     private void madeInternalResponseDto(List<TopUserReviewDto> topUserReviewDtos,
-        List<TopUserResponseDto> top5UserResponseDtos, User user) {
+        List<TopUserResponseDto> top5UserResponseDtos, User user, User loginUser) {
         int followers = user.getFollowStates().size();
         log.info(yesterday.toString());
         Long following = followRepository.countByFollowedUserId(user.getId());
@@ -63,7 +73,7 @@ public class TodayBestUserService {
         Pageable remainPageable = PageRequest.of(0, 2);
         addNewestReview(topUserReviewDtos, user, remainPageable);
         TopUserResponseDto topUserResponseDto = buildTopUserResponseDto(
-            topUserReviewDtos, user, followers, following);
+            topUserReviewDtos, user, followers, following, loginUser);
         top5UserResponseDtos.add(topUserResponseDto);
     }
 
@@ -88,8 +98,8 @@ public class TodayBestUserService {
         }
     }
 
-    private static TopUserResponseDto buildTopUserResponseDto(
-        List<TopUserReviewDto> topUserReviewDtos, User user, int followers, Long following) {
+    private TopUserResponseDto buildTopUserResponseDto(
+        List<TopUserReviewDto> topUserReviewDtos, User user, int followers, Long following, User loginUser) {
         TopUserResponseDto topUserResponseDto = TopUserResponseDto.builder()
             .userId(user.getId())
             .profileImg(user.getProfileImg())
@@ -99,8 +109,19 @@ public class TodayBestUserService {
             .followers(followers)
             .followings(following)
             .reviews(topUserReviewDtos)
+            .isLoginedUserFollowsNowUser(getIsLoginUserPushFollow(loginUser, user))
             .build();
         return topUserResponseDto;
+    }
+
+    private Boolean getIsLoginUserPushFollow(User loginUser, User user) {
+
+        Optional<FollowState> byPushUserAndFollowUser = followRepository.findByPushUserAndFollowUser(
+            loginUser.getId(), user.getId());
+        if(byPushUserAndFollowUser.isEmpty()){
+            return false;
+        }
+        return true;
     }
 
     private TopUserReviewDto getTopUserReviewDto(Review topReview) {

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movie/MovieCrawlService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movie/MovieCrawlService.java
@@ -290,7 +290,7 @@ public class MovieCrawlService {
     public List<MoviePopularDto> getPopularMovies(){
         RestTemplate restTemplate = new RestTemplate();
         popularMovieRepository.deleteAll();
-        ResponseEntity<String> responseEntity = restTemplate.getForEntity("https://api.themoviedb.org/3/movie/popular" + "?api_key=" + API_KEY+"&language=ko-KR", String.class);
+        ResponseEntity<String> responseEntity = restTemplate.getForEntity("https://api.themoviedb.org/3/movie/popular?api_key=" + API_KEY+"&language=ko-KR", String.class);
         String json = responseEntity.getBody();
         ObjectMapper objectMapper = new ObjectMapper();
         List<Map<String, Object>> movies = new ArrayList<>();
@@ -402,7 +402,7 @@ public class MovieCrawlService {
     }
 
     private MovieRecommendDto mapMovieToResponseDto(Movie movie) {
-        Float averageStarScore = reviewRepository.findAvgScoreByMovieId(movie.getId());
+        Float averageStarScore = starRepository.findAvgScoreByMovieId(movie.getId());
 
         return MovieRecommendDto.builder()
                 .movieId(movie.getId())

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/review/ReviewService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/review/ReviewService.java
@@ -23,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -190,16 +189,16 @@ public class ReviewService {
 
         ReviewInfoDto reviewInfoDto = ReviewInfoDto.builder()
             .reviewId(review.getReviewId())
-            .hasCheckDate(review.getHasCheckDate())
-            .hasGoodActing(review.getHasGoodActing())
-            .hasGoodDiction(review.getHasGoodDiction())
-            .hasSpoiler(review.getHasSpoiler())
-            .hasGoodDirecting(review.getHasGoodDirecting())
-            .hasGoodOst(review.getHasGoodOst())
-            .hasGoodScenario(review.getHasGoodScenario())
-            .hasGoodProduction(review.getHasGoodProduction())
-            .hasGoodVisual(review.getHasGoodVisual())
-            .hasGoodCharterCharming(review.getHasGoodCharterCharming())
+            .hasCheckDate(validateNull(review.getHasCheckDate()))
+            .hasGoodActing(validateNull(review.getHasGoodActing()))
+            .hasGoodDiction(validateNull(review.getHasGoodDiction()))
+            .hasSpoiler(validateNull(review.getHasSpoiler()))
+            .hasGoodDirecting(validateNull(review.getHasGoodDirecting()))
+            .hasGoodOst(validateNull(review.getHasGoodOst()))
+            .hasGoodScenario(validateNull(review.getHasGoodScenario()))
+            .hasGoodProduction(validateNull(review.getHasGoodProduction()))
+            .hasGoodVisual(validateNull(review.getHasGoodVisual()))
+            .hasGoodCharterCharming(validateNull(review.getHasGoodCharterCharming()))
             .reviewTitle(review.getReviewTitle())
             .reviewMainText(review.getReviewMainText())
             .star(review.getStar())
@@ -209,6 +208,14 @@ public class ReviewService {
 
         return reviewInfoDto;
     }
+
+    private Boolean validateNull(Boolean feature) {
+        if(feature==null){
+            return false;
+        }
+        return feature;
+    }
+
     @Transactional
     public ResponseEntity getMovieInfo(Long movieId) {
         try {

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/singleMoviePage/SingleMoviePageService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/singleMoviePage/SingleMoviePageService.java
@@ -12,6 +12,7 @@ import com.ItsTime.ItNovation.domain.review.dto.SingleMoviePageReviewInfoDto;
 import com.ItsTime.ItNovation.domain.reviewLike.ReviewLikeRepository;
 import com.ItsTime.ItNovation.domain.singleMoviePage.SingleMoviePageResponseDto;
 import com.ItsTime.ItNovation.domain.singleMoviePage.SingleMoviePageReviewAndUserDto;
+import com.ItsTime.ItNovation.domain.star.StarRepository;
 import com.ItsTime.ItNovation.domain.user.User;
 import com.ItsTime.ItNovation.domain.user.dto.SingleMoviePageUserInfoDto;
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ public class SingleMoviePageService {
     private final ReviewRepository reviewRepository;
     private final ReviewLikeRepository reviewLikeRepository;
     private final MovieLikeRepository movieLikeRepository;
-
+    private final StarRepository starRepository;
 
 
     @Transactional
@@ -80,10 +81,11 @@ public class SingleMoviePageService {
     private SingleMoviePageMovieInfoDto madeSingleMovieDto(Movie movie) {
         SingleMoviePageMovieInfoDto singleMoviePageMovieInfoDto = SingleMoviePageMovieInfoDto.builder()
             .movieImg(movie.getMovieImg())
+            .movieBgImg(movie.getMovieBgImg())
             .movieActor(movie.getMovieActor())
             .movieDetail(movie.getMovieDetail())
             .movieGenre(movie.getMovieGenre())
-            .avgStarScore(4.0f)
+            .avgStarScore(starRepository.findAvgScoreByMovieId(movie.getId()))
             .title(movie.getTitle())
             .movieLikeCount(movieLikeRepository.countMovieLike(movie))
             .movieRunningTime(movie.getMovieRunningTime())

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/singleMoviePage/SingleMoviePageService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/singleMoviePage/SingleMoviePageService.java
@@ -88,6 +88,9 @@ public class SingleMoviePageService {
             .movieLikeCount(movieLikeRepository.countMovieLike(movie))
             .movieRunningTime(movie.getMovieRunningTime())
             .movieReleasedDate(movie.getMovieDate())
+            .movieDirector(movie.getMovieDirector())
+            .movieCountry(movie.getMovieCountry())
+            .movieAge(movie.getMovieAudit())
             .top3HasFeature(findTop3Feature(movie))
             .build();
         return singleMoviePageMovieInfoDto;

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/top/TopKeywordService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/top/TopKeywordService.java
@@ -31,9 +31,7 @@ public class TopKeywordService {
 
         try {
             Movie movie = movieRepository.findById(movieId)
-
                     .orElseThrow(() -> new IllegalArgumentException("해당 영화가 존재하지 않습니다."));
-
 
             MovieFeatureDto featureCount = getFeatureCount(featureCountMap, movie);
             return ResponseEntity.status(200).body(featureCount);


### PR DESCRIPTION
### 패치노트

1. following, follower 명수를 response에 추가
2. login한 유저와 review를 작성한 유저와의 관계 response 추가 (follow했는지, 리뷰에 대해 좋아요를 눌렀는지)

----

### 패치노트 ver 2

singleMoviePage 관련 추가 패치 진행

1. movieDirector, movieAge, movieCountry가 response값에 추가되었습니다.
2. movieBgImg 추가
3. 이제 영화의 star 값 4.0 고정이 아닌 repository의 값을 계산해서 전달

---
### 패치노트 ver 3    date : 07.19

singleMoviePage 관련 추가 패치 진행

1. login한 유저에 대해서 필요한 데이터
     -  리뷰별점, 영화 좋아요 눌렀는지, 영화 별점 추가
2. avgStarScore 관련 null 값 전송되던 부분 수정 0점을 전달하도록!

![image](https://github.com/IT-NOVATION/BackEnd/assets/38220795/f9eaea0b-6564-4c8a-927d-7c47b9b55568)

---
### 패치노트 ver 3.1 date: 07.20
1. 리뷰 읽기 관련 feature 들 null 값 처리 추가

---
### 패치노트 ver 3.2 date: 07.21
1. topUser 관련 유저 팔로우 됬는지 여부에 따라 처리
2. popular에 starScore담는 기능 .