### PR TITLE
댓글 관련 추가!

### DIFF
--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/config/SecurityConfig.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/config/SecurityConfig.java
@@ -68,10 +68,8 @@ public class SecurityConfig {
             new AntPathRequestMatcher("/single/movie/reviewCount/**"),
             new AntPathRequestMatcher("/review/movieInfo/**"),
             new AntPathRequestMatcher("/custom-logout"),
-            new AntPathRequestMatcher("/movielog/**")
-
-
-
+            new AntPathRequestMatcher("/movielog/**"),
+            new AntPathRequestMatcher("/comment/read/**")
 
 
             );

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/comment/CommentController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/comment/CommentController.java
@@ -6,6 +6,7 @@ import com.ItsTime.ItNovation.service.comment.CommentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,10 +22,11 @@ public class CommentController {
 
 
     private final CommentService commentService;
-
     @PostMapping("/write")
-    public ResponseEntity commentWrite(@RequestBody CommentWriteRequestDto commentDto){
-        return commentService.writeComment(commentDto);
+    public ResponseEntity commentWrite(@RequestBody CommentWriteRequestDto commentDto, Authentication authentication){
+        String email = authentication.getName();
+
+        return commentService.writeComment(commentDto, email);
     }
 
 

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/comment/CommentController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/comment/CommentController.java
@@ -1,0 +1,50 @@
+package com.ItsTime.ItNovation.controller.comment;
+
+
+import com.ItsTime.ItNovation.domain.comment.dto.CommentWriteRequestDto;
+import com.ItsTime.ItNovation.service.comment.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/comment")
+@RequiredArgsConstructor
+@Slf4j
+public class CommentController {
+
+
+    private final CommentService commentService;
+
+    @PostMapping("/write")
+    public ResponseEntity commentWrite(@RequestBody CommentWriteRequestDto commentDto){
+        return commentService.writeComment(commentDto);
+    }
+
+
+    /**
+     *
+     * @param page 당 댓글 5개
+     * @return
+     */
+    @GetMapping("/read/{page}")
+    public ResponseEntity commentRead(@PathVariable int page){
+        return commentService.readComment(page);
+    }
+
+
+
+    @GetMapping("/delete/{commentId}")
+    public ResponseEntity commentDelete(@PathVariable Long commentId){
+        return commentService.deleteComment(commentId);
+    }
+
+
+
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/comment/CommentController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/comment/CommentController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,9 +36,9 @@ public class CommentController {
      * @param page 당 댓글 5개
      * @return
      */
-    @GetMapping("/read/{page}")
-    public ResponseEntity commentRead(@PathVariable int page){
-        return commentService.readComment(page);
+    @GetMapping("/read")
+    public ResponseEntity commentRead(@RequestParam("page") int page, @RequestParam("reviewId") Long reviewId){
+        return commentService.readComment(page, reviewId);
     }
 
 

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/Comment.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/Comment.java
@@ -1,0 +1,47 @@
+package com.ItsTime.ItNovation.domain.comment;
+
+
+import com.ItsTime.ItNovation.domain.BaseTimeEntity;
+import com.ItsTime.ItNovation.domain.review.Review;
+import com.ItsTime.ItNovation.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name= "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="review_id")
+    private Review review;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String commentText;
+    @Builder
+    public Comment(User user, Review review, String commentText) {
+        this.user = user;
+        this.review = review;
+        this.commentText = commentText;
+    }
+
+
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/CommentRepository.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/CommentRepository.java
@@ -4,12 +4,13 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 
-    @Query("SELECT c FROM Comment c ORDER BY c.createdDate DESC")
-    List<Comment> findByNewestComment(Pageable pageable);
+    @Query("SELECT c FROM Comment c WHERE c.review.reviewId = :reviewId ORDER BY c.createdDate DESC")
+    List<Comment> findByNewestComment(@Param("reviewId")Long reviewId, Pageable pageable);
 
 
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/CommentRepository.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/CommentRepository.java
@@ -1,0 +1,15 @@
+package com.ItsTime.ItNovation.domain.comment;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+
+    @Query("SELECT c FROM Comment c ORDER BY c.createdDate DESC")
+    List<Comment> findByNewestComment(Pageable pageable);
+
+
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/CommentRepository.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.ItsTime.ItNovation.domain.comment;
 
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByNewestComment(@Param("reviewId")Long reviewId, Pageable pageable);
 
 
+    @Query("select c from Comment  c where c.review.reviewId=:reviewId")
+    List<Comment> findAllByReviewId(@Param("reviewId") Long reviewId);
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentReadDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentReadDto.java
@@ -1,0 +1,22 @@
+package com.ItsTime.ItNovation.domain.comment.dto;
+
+
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentReadDto {
+
+    private Long commentId;
+    private String commentText;
+    private String createDate;
+
+
+    @Builder
+    public CommentReadDto(Long commentId, String commentText, String createDate) {
+        this.commentId = commentId;
+        this.commentText = commentText;
+        this.createDate = createDate;
+    }
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentReadDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentReadDto.java
@@ -11,12 +11,14 @@ public class CommentReadDto {
     private Long commentId;
     private String commentText;
     private String createDate;
+    private CommentUserInfoDto commentUserInfo;
 
 
     @Builder
-    public CommentReadDto(Long commentId, String commentText, String createDate) {
+    public CommentReadDto(Long commentId, String commentText, String createDate, CommentUserInfoDto commentUserInfo) {
         this.commentId = commentId;
         this.commentText = commentText;
         this.createDate = createDate;
+        this.commentUserInfo = commentUserInfo;
     }
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentReadResponseDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentReadResponseDto.java
@@ -12,15 +12,17 @@ public class CommentReadResponseDto {
     private int lastPage;
     private int firstPage;
     private int nowPage;
+    private int totalCommentCount;
     private List<CommentReadDto> commentList;
 
 
     @Builder
-    public CommentReadResponseDto(int lastPage, int firstPage, int nowPage,
+    public CommentReadResponseDto(int lastPage, int firstPage, int nowPage, int totalCommentCount,
         List<CommentReadDto> commentList) {
         this.lastPage = lastPage;
         this.firstPage = firstPage;
         this.nowPage = nowPage;
+        this.totalCommentCount = totalCommentCount;
         this.commentList = commentList;
     }
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentReadResponseDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentReadResponseDto.java
@@ -1,0 +1,26 @@
+package com.ItsTime.ItNovation.domain.comment.dto;
+
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentReadResponseDto {
+
+
+    private int lastPage;
+    private int firstPage;
+    private int nowPage;
+    private List<CommentReadDto> commentList;
+
+
+    @Builder
+    public CommentReadResponseDto(int lastPage, int firstPage, int nowPage,
+        List<CommentReadDto> commentList) {
+        this.lastPage = lastPage;
+        this.firstPage = firstPage;
+        this.nowPage = nowPage;
+        this.commentList = commentList;
+    }
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentUserInfoDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentUserInfoDto.java
@@ -1,0 +1,21 @@
+package com.ItsTime.ItNovation.domain.comment.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentUserInfoDto {
+
+    private Long userId;
+    private String profileImg;
+    private String nickname;
+
+
+    @Builder
+    public CommentUserInfoDto(Long userId, String profileImg, String nickname) {
+        this.userId = userId;
+        this.profileImg = profileImg;
+        this.nickname = nickname;
+    }
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentWriteRequestDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentWriteRequestDto.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 
 @Getter
 public class CommentWriteRequestDto {
-    private Long userId;
     private Long reviewId;
     private String commentText;
-
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentWriteRequestDto.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/comment/dto/CommentWriteRequestDto.java
@@ -1,0 +1,13 @@
+package com.ItsTime.ItNovation.domain.comment.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentWriteRequestDto {
+    private Long userId;
+    private Long reviewId;
+    private String commentText;
+
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/review/Review.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/review/Review.java
@@ -3,10 +3,12 @@ package com.ItsTime.ItNovation.domain.review;
 
 
 import com.ItsTime.ItNovation.domain.BaseTimeEntity;
+import com.ItsTime.ItNovation.domain.comment.Comment;
 import com.ItsTime.ItNovation.domain.movie.Movie;
 import com.ItsTime.ItNovation.domain.reviewLike.ReviewLike;
 import com.ItsTime.ItNovation.domain.user.User;
 import jakarta.persistence.*;
+import java.util.ArrayList;
 import lombok.*;
 
 import java.util.Date;
@@ -61,12 +63,14 @@ public class Review extends BaseTimeEntity {
 
     //비식별 관계 사용 - 다쪽 엔티티가 일쪽 엔티티의 외래키를 가지는 형태 -> 서로 독립적, 유연
     @OneToMany(mappedBy = "review")
-    private List<ReviewLike> reviewLikes;
+    private List<ReviewLike> reviewLikes = new ArrayList<>();
 
+
+    @OneToMany(mappedBy = "review")
+    private List<Comment> commentList = new ArrayList<>();
 
     @Builder
     public Review( Float star, String reviewTitle, String reviewMainText, Boolean hasGoodStory, Boolean hasGoodProduction, Boolean hasGoodScenario, Boolean hasGoodDirecting, Boolean hasGoodOst, Boolean hasGoodVisual, Boolean hasGoodActing, Boolean hasGoodCharterCharming, Boolean hasGoodDiction, Boolean hasCheckDate, Boolean hasSpoiler, String watchDate, Movie movie, User user, List<ReviewLike> reviewLikes) {
-
         this.star = star;
         this.reviewTitle = reviewTitle;
         this.reviewMainText = reviewMainText;

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/User.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/user/User.java
@@ -1,10 +1,12 @@
 package com.ItsTime.ItNovation.domain.user;
 
 import com.ItsTime.ItNovation.domain.BaseTimeEntity;
+import com.ItsTime.ItNovation.domain.comment.Comment;
 import com.ItsTime.ItNovation.domain.follow.FollowState;
 import com.ItsTime.ItNovation.domain.review.Review;
 import com.ItsTime.ItNovation.domain.reviewLike.ReviewLike;
 import jakarta.persistence.*;
+import java.util.ArrayList;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,14 +41,17 @@ public class User extends BaseTimeEntity {
 
 
     @OneToMany(mappedBy = "user")
-    private List<Review> reviews;
+    private List<Review> reviews = new ArrayList<>();
 
     //ReviewLike 엔티티 클래스가 Review 엔티티 클래스의 reviewId 필드를 참조하여 연관관계를 맺고 있다는 것
     @OneToMany(mappedBy= "user")
-    private List<ReviewLike> reviewLikes;
+    private List<ReviewLike> reviewLikes = new ArrayList<>();
 
     @OneToMany(mappedBy = "pushUser")
-    private List<FollowState> followStates;
+    private List<FollowState> followStates = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Comment> commentList = new ArrayList<>();
 
 
     // 유저 권한 설정 메소드

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/best/TodayBestUserService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/best/TodayBestUserService.java
@@ -115,7 +115,9 @@ public class TodayBestUserService {
     }
 
     private Boolean getIsLoginUserPushFollow(User loginUser, User user) {
-
+        if(loginUser == null){
+            return false;
+        }
         Optional<FollowState> byPushUserAndFollowUser = followRepository.findByPushUserAndFollowUser(
             loginUser.getId(), user.getId());
         if(byPushUserAndFollowUser.isEmpty()){

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -10,11 +10,13 @@ import com.ItsTime.ItNovation.domain.review.Review;
 import com.ItsTime.ItNovation.domain.review.ReviewRepository;
 import com.ItsTime.ItNovation.domain.user.User;
 import com.ItsTime.ItNovation.domain.user.UserRepository;
+import com.ItsTime.ItNovation.service.grade.GradeService;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CommentService {
 
     private final CommentRepository commentRepository;
@@ -64,13 +67,16 @@ public class CommentService {
             validatePageRequest(page, lastPage);
             CommentReadResponseDto responseDto = getCommentReadResponseDto(
                 page, newestByComment, commentReadDtoList, lastPage);
+
             return ResponseEntity.status(200).body(responseDto);
         } catch (Exception e) {
             return ResponseEntity.status(400).body(e.getMessage());
         }
     }
 
-    private static void validatePageRequest(int page, int lastPage) {
+    private void validatePageRequest(int page, int lastPage) {
+        log.info(String.valueOf(lastPage));
+        log.info(String.valueOf(page));
         if (lastPage < page) {
             throw new IllegalArgumentException("잘못된 페이지를 호출하였습니다!");
         }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -60,7 +60,7 @@ public class CommentService {
             Pageable pageable = PageRequest.of(page - 1, 15);
             List<Comment> newestByComment = commentRepository.findByNewestComment(reviewId, pageable);
             List<CommentReadDto> commentReadDtoList = new ArrayList<>();
-            int lastPage = getLastPage();
+            int lastPage = getLastPage(reviewId);
             validatePageRequest(page, lastPage);
             CommentReadResponseDto responseDto = getCommentReadResponseDto(
                 page, newestByComment, commentReadDtoList, lastPage);
@@ -111,9 +111,9 @@ public class CommentService {
         return formattedDateTime;
     }
 
-    private int getLastPage() {
-        if (commentRepository.findAll().size() % 15 == 0) {
-            return commentRepository.findAll().size() / 15;
+    private int getLastPage(Long reviewId) {
+        if (commentRepository.findAllByReviewId(reviewId).size() % 15 == 0) {
+            return commentRepository.findAllByReviewId(reviewId).size() / 15;
         }
         return commentRepository.findAll().size() / 15 + 1;
     }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -63,6 +63,7 @@ public class CommentService {
 
             Pageable pageable = PageRequest.of(page - 1, 15);
             List<Comment> newestByComment = commentRepository.findByNewestComment(reviewId, pageable);
+            log.info(String.valueOf(newestByComment.size()));
             List<CommentReadDto> commentReadDtoList = new ArrayList<>();
             int lastPage = getLastPage(reviewId);
             if(lastPage==0){
@@ -137,7 +138,7 @@ public class CommentService {
         if (commentRepository.findAllByReviewId(reviewId).size() % 15 == 0) {
             return commentRepository.findAllByReviewId(reviewId).size() / 15;
         }
-        return commentRepository.findAll().size() / 15 + 1;
+        return commentRepository.findAllByReviewId(reviewId).size() / 15 + 1;
     }
 
     @Transactional

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -57,7 +57,7 @@ public class CommentService {
     public ResponseEntity readComment(int page, Long reviewId) {
         try {
 
-            Pageable pageable = PageRequest.of(page - 1, 5);
+            Pageable pageable = PageRequest.of(page - 1, 15);
             List<Comment> newestByComment = commentRepository.findByNewestComment(reviewId, pageable);
             List<CommentReadDto> commentReadDtoList = new ArrayList<>();
             int lastPage = getLastPage();
@@ -123,7 +123,7 @@ public class CommentService {
         try {
             commentRepository.deleteById(commentId);
 
-            GradeService.checkGrade()
+            //GradeService.checkGrade()
             return ResponseEntity.status(200).body("삭제 성공했습니다.");
         } catch (Exception e) {
             return ResponseEntity.status(400).body("삭제에 실패했습니다.");

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -5,6 +5,7 @@ import com.ItsTime.ItNovation.domain.comment.Comment;
 import com.ItsTime.ItNovation.domain.comment.CommentRepository;
 import com.ItsTime.ItNovation.domain.comment.dto.CommentReadDto;
 import com.ItsTime.ItNovation.domain.comment.dto.CommentReadResponseDto;
+import com.ItsTime.ItNovation.domain.comment.dto.CommentUserInfoDto;
 import com.ItsTime.ItNovation.domain.comment.dto.CommentWriteRequestDto;
 import com.ItsTime.ItNovation.domain.review.Review;
 import com.ItsTime.ItNovation.domain.review.ReviewRepository;
@@ -107,8 +108,18 @@ public class CommentService {
             .commentText(nowComment.getCommentText())
             .commentId(nowComment.getId())
             .createDate(getCreatedDate(nowComment))
+            .commentUserInfo(buildCommentUserInfo(nowComment))
             .build();
         return readDto;
+    }
+
+    private CommentUserInfoDto buildCommentUserInfo(Comment nowComment) {
+        User user = nowComment.getUser();
+        return CommentUserInfoDto.builder()
+            .userId(user.getId())
+            .profileImg(user.getProfileImg())
+            .nickname(user.getNickname())
+            .build();
     }
 
     private String getCreatedDate(Comment nowComment) {

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -64,6 +64,9 @@ public class CommentService {
             List<Comment> newestByComment = commentRepository.findByNewestComment(reviewId, pageable);
             List<CommentReadDto> commentReadDtoList = new ArrayList<>();
             int lastPage = getLastPage(reviewId);
+            if(lastPage==0){
+                lastPage=1;
+            }
             validatePageRequest(page, lastPage);
             CommentReadResponseDto responseDto = getCommentReadResponseDto(
                 page, newestByComment, commentReadDtoList, lastPage);
@@ -118,6 +121,8 @@ public class CommentService {
     }
 
     private int getLastPage(Long reviewId) {
+
+
         if (commentRepository.findAllByReviewId(reviewId).size() % 15 == 0) {
             return commentRepository.findAllByReviewId(reviewId).size() / 15;
         }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -1,0 +1,129 @@
+package com.ItsTime.ItNovation.service.comment;
+
+
+import com.ItsTime.ItNovation.domain.comment.Comment;
+import com.ItsTime.ItNovation.domain.comment.CommentRepository;
+import com.ItsTime.ItNovation.domain.comment.dto.CommentReadDto;
+import com.ItsTime.ItNovation.domain.comment.dto.CommentReadResponseDto;
+import com.ItsTime.ItNovation.domain.comment.dto.CommentWriteRequestDto;
+import com.ItsTime.ItNovation.domain.review.Review;
+import com.ItsTime.ItNovation.domain.review.ReviewRepository;
+import com.ItsTime.ItNovation.domain.user.User;
+import com.ItsTime.ItNovation.domain.user.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    @Transactional
+    public ResponseEntity writeComment(CommentWriteRequestDto commentDto) {
+        try {
+            Comment comment = Comment.builder()
+                .commentText(commentDto.getCommentText())
+                .review(getReview(commentDto))
+                .user(getUser(commentDto))
+                .build();
+            commentRepository.save(comment);
+            return ResponseEntity.status(200).body("성공적으로 저장되었습니다.");
+        }catch (IllegalArgumentException e){
+            return ResponseEntity.status(400).body(e.getMessage());
+        }
+    }
+
+    private User getUser(CommentWriteRequestDto commentDto) {
+        User user = userRepository.findById(commentDto.getUserId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+        return user;
+    }
+
+    private Review getReview(CommentWriteRequestDto commentDto) {
+        Review review = reviewRepository.findById(commentDto.getReviewId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 리뷰가 없습니다."));
+        return review;
+    }
+
+
+    @Transactional
+    public ResponseEntity readComment(int page) {
+        try {
+            Pageable pageable = PageRequest.of(page - 1, 5);
+            List<Comment> newestByComment = commentRepository.findByNewestComment(pageable);
+            List<CommentReadDto> commentReadDtoList = new ArrayList<>();
+            int lastPage = getLastPage();
+                CommentReadResponseDto responseDto = getCommentReadResponseDto(
+                    page, newestByComment, commentReadDtoList, lastPage);
+                return ResponseEntity.status(200).body(responseDto);
+        }catch (Exception e){
+            return ResponseEntity.status(400).body("댓글을 읽는데 오류가 발생했습니다.");
+        }
+    }
+
+    private CommentReadResponseDto getCommentReadResponseDto(int page,
+        List<Comment> newestByComment, List<CommentReadDto> commentReadDtoList, int lastPage) {
+        for(int i=0; i< newestByComment.size(); i++){
+            Comment nowComment = newestByComment.get(i);
+            CommentReadDto readDto = buildReadDto(nowComment);
+            commentReadDtoList.add(readDto);
+        }
+
+        CommentReadResponseDto responseDto = CommentReadResponseDto.builder()
+            .commentList(commentReadDtoList)
+            .lastPage(lastPage)
+            .nowPage(page)
+            .firstPage(1)
+            .build();
+        return responseDto;
+    }
+
+    private CommentReadDto buildReadDto(Comment nowComment) {
+        CommentReadDto readDto = CommentReadDto.builder()
+            .commentText(nowComment.getCommentText())
+            .commentId(nowComment.getId())
+            .createDate(getCreatedDate(nowComment))
+            .build();
+        return readDto;
+    }
+
+    private String getCreatedDate(Comment nowComment) {
+        LocalDateTime createdDate = nowComment.getCreatedDate();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+        String formattedDateTime = createdDate.format(formatter);
+
+        return formattedDateTime;
+    }
+
+    private int getLastPage() {
+        if(commentRepository.findAll().size()%5==0){
+            return commentRepository.findAll().size()/5;
+        }
+        return commentRepository.findAll().size()/5+1;
+    }
+
+    @Transactional
+    public ResponseEntity deleteComment(Long commentId) {
+        try {
+            commentRepository.deleteById(commentId);
+            return ResponseEntity.status(200).body("삭제 성공했습니다.");
+        }catch (Exception e){
+            return ResponseEntity.status(400).body("삭제에 실패했습니다.");
+        }
+    }
+}

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -14,12 +14,10 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.web.server.authentication.AnonymousAuthenticationWebFilter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,10 +54,11 @@ public class CommentService {
 
 
     @Transactional
-    public ResponseEntity readComment(int page) {
+    public ResponseEntity readComment(int page, Long reviewId) {
         try {
-            Pageable pageable = PageRequest.of(page - 1, 15);
-            List<Comment> newestByComment = commentRepository.findByNewestComment(pageable);
+
+            Pageable pageable = PageRequest.of(page - 1, 5);
+            List<Comment> newestByComment = commentRepository.findByNewestComment(reviewId, pageable);
             List<CommentReadDto> commentReadDtoList = new ArrayList<>();
             int lastPage = getLastPage();
             validatePageRequest(page, lastPage);
@@ -123,6 +122,8 @@ public class CommentService {
     public ResponseEntity deleteComment(Long commentId) {
         try {
             commentRepository.deleteById(commentId);
+
+            GradeService.checkGrade()
             return ResponseEntity.status(200).body("삭제 성공했습니다.");
         } catch (Exception e) {
             return ResponseEntity.status(400).body("삭제에 실패했습니다.");

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -71,7 +71,7 @@ public class CommentService {
             }
             validatePageRequest(page, lastPage);
             CommentReadResponseDto responseDto = getCommentReadResponseDto(
-                page, newestByComment, commentReadDtoList, lastPage);
+                page, reviewId, newestByComment, commentReadDtoList, lastPage);
 
             return ResponseEntity.status(200).body(responseDto);
         } catch (Exception e) {
@@ -87,7 +87,7 @@ public class CommentService {
         }
     }
 
-    private CommentReadResponseDto getCommentReadResponseDto(int page,
+    private CommentReadResponseDto getCommentReadResponseDto(int page, Long reviewId,
         List<Comment> newestByComment, List<CommentReadDto> commentReadDtoList, int lastPage) {
         for (int i = 0; i < newestByComment.size(); i++) {
             Comment nowComment = newestByComment.get(i);
@@ -99,6 +99,7 @@ public class CommentService {
             .commentList(commentReadDtoList)
             .lastPage(lastPage)
             .nowPage(page)
+            .totalCommentCount(commentRepository.findAllByReviewId(reviewId).size())
             .firstPage(1)
             .build();
         return responseDto;

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/comment/CommentService.java
@@ -58,7 +58,7 @@ public class CommentService {
     @Transactional
     public ResponseEntity readComment(int page) {
         try {
-            Pageable pageable = PageRequest.of(page - 1, 5);
+            Pageable pageable = PageRequest.of(page - 1, 15);
             List<Comment> newestByComment = commentRepository.findByNewestComment(pageable);
             List<CommentReadDto> commentReadDtoList = new ArrayList<>();
             int lastPage = getLastPage();
@@ -113,10 +113,10 @@ public class CommentService {
     }
 
     private int getLastPage() {
-        if (commentRepository.findAll().size() % 5 == 0) {
-            return commentRepository.findAll().size() / 5;
+        if (commentRepository.findAll().size() % 15 == 0) {
+            return commentRepository.findAll().size() / 15;
         }
-        return commentRepository.findAll().size() / 5 + 1;
+        return commentRepository.findAll().size() / 15 + 1;
     }
 
     @Transactional

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/grade/GradeService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/grade/GradeService.java
@@ -1,0 +1,11 @@
+package com.ItsTime.ItNovation.service.grade;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class GradeService {
+
+
+
+
+}


### PR DESCRIPTION
## 패치노트 07.21

*  댓글 관련 CRD 제작하였습니다! 중간에 커밋메시지 잘못 있는거 CRU 가 아니라 CRD입니다!

1. 댓글 관련 페이지네이션 적용시켜서 전송하였습니다. 
2. 자세한 사항은 API 명세서 참고해주세요!


** 추가로 topUser 관련 null 로 인한 오류 수정하였습니다!

---

## 패치노트 07.22

1. 댓글 읽기 url SecurityConfig에 추가했습니다.
2. 댓글 읽기 할 때 comment에 대한 user 정보들 response에 넣어서 전달했습니다! API 명세서를 참고해주세요!