### PR TITLE
[FIX] 무비토크에서 유저 상태 비교하는 변수가 전역으로 선언되어있어서 버그가 발생한 문제 해결

### DIFF
--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/top/TopController.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/controller/top/TopController.java
@@ -1,9 +1,8 @@
 package com.ItsTime.ItNovation.controller.top;
 
 
-import com.ItsTime.ItNovation.common.exception.UnauthorizedException;
 import com.ItsTime.ItNovation.config.jwt.service.JwtService;
-import com.ItsTime.ItNovation.service.top.TodayBestUserService;
+import com.ItsTime.ItNovation.service.top.YesterdayBestUserService;
 import com.ItsTime.ItNovation.service.top.TopKeywordService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class TopController {
     private final TopKeywordService topKeywordService;
-    private final TodayBestUserService todayBestUserService;
+    private final YesterdayBestUserService yesterdayBestUserService;
     private final JwtService jwtService;
 
     @GetMapping("/movie-keyword/{movieId}")
@@ -40,12 +39,12 @@ public class TopController {
         if (s.isPresent()) {
             Optional<String> email = jwtService.extractEmail(s.get());
             if (email.isPresent()) {
-                return todayBestUserService.getBestUserInfo(email.get());
+                return yesterdayBestUserService.getBestUserInfo(email.get());
             }
 
         }
 
-        return todayBestUserService.getBestUserInfo(null);
+        return yesterdayBestUserService.getBestUserInfo(null);
     }
 
 }

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieTalk/TodayBestReviewService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieTalk/TodayBestReviewService.java
@@ -42,6 +42,7 @@ public class TodayBestReviewService {
 
     @Transactional
     public ResponseEntity getBestReviewAndUser(Optional<String> accessToken) {
+        nowUserEmail = null;
         if (accessToken.isPresent()) {
             Optional<String> extractedEmail = jwtService.extractEmail(accessToken.get());
             extractedEmail.ifPresent(s -> nowUserEmail = s);

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieTalk/TodayLatestReviewService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieTalk/TodayLatestReviewService.java
@@ -40,14 +40,11 @@ public class TodayLatestReviewService {
 
     @Transactional
     public ResponseEntity getLatestReviews(Optional<String> accessToken) {
+        nowUserEmail = null;
         if (accessToken.isPresent()) {
             Optional<String> extractedEmail = jwtService.extractEmail(accessToken.get());
+            extractedEmail.ifPresent(s -> nowUserEmail = s);
 
-            try{
-                extractedEmail.ifPresent(s -> nowUserEmail = s);
-            }catch(UnauthorizedException e){
-
-            }
         }
         List<User> recentReviewers = reviewRepository.findUsersWithNewestReview(PageRequest.of(0, 3));
         List<LatestReviewResponseDto> LatestReviewResponseList = new ArrayList<>();

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieTalk/TodayPopularUserService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieTalk/TodayPopularUserService.java
@@ -34,15 +34,10 @@ public class TodayPopularUserService {
 
     @Transactional
     public ResponseEntity getTopFollowers(Optional<String> accessToken) {
-
+        nowUserEmail = null;
         if (accessToken.isPresent()) {
-            try{
-                Optional<String> extractedEmail = jwtService.extractEmail(accessToken.get());
-                extractedEmail.ifPresent(s -> nowUserEmail = s);
-            }catch(UnauthorizedException e){
-                throw new UnauthorizedException(e.getErrorCode());
-            }
-
+            Optional<String> extractedEmail = jwtService.extractEmail(accessToken.get());
+            extractedEmail.ifPresent(s -> nowUserEmail = s);
         }
         log.info(nowUserEmail);
         Pageable pageable = PageRequest.of(0, 2);

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/top/YesterdayBestUserService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/top/YesterdayBestUserService.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class TodayBestUserService {
+public class YesterdayBestUserService {
 
 
     private final ReviewLikeRepository reviewLikeRepository;
@@ -36,7 +36,7 @@ public class TodayBestUserService {
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
 
-    private final LocalDate yesterday = LocalDate.now().minusDays(1);
+    private  LocalDate yesterday = LocalDate.now().minusDays(1);
 
     /**
      * Todo -> 전날 기준 집계해서 top User 뽑는 방식으로 고려
@@ -45,9 +45,9 @@ public class TodayBestUserService {
     @Transactional
     public ResponseEntity getBestUserInfo(String email) {
         Pageable pageable = PageRequest.of(0, 5);
-        log.info("hello");
+        yesterday = LocalDate.now().minusDays(1);
         List<User> top5UsersWithTodayDate = reviewLikeRepository.findTopUsersWithYesterdayDate(yesterday,
-            pageable); // -> 이거 전날 기준으로 고쳐야 함!
+            pageable);
         System.out.println("top5UsersWithTodayDate = " + top5UsersWithTodayDate);
 
         List<TopUserResponseDto> top5UserResponseDtos = new ArrayList<>();
@@ -76,7 +76,6 @@ public class TodayBestUserService {
     private void madeInternalResponseDto(List<TopUserReviewDto> topUserReviewDtos,
         List<TopUserResponseDto> top5UserResponseDtos, User user, User loginUser) {
         Long following = (long) user.getFollowStates().size();
-        log.info(yesterday.toString());
         Long followers = followRepository.countByFollowedUserId(user.getId());
         List<Review> reviews = reviewLikeRepository.bestReviewsByUserId(yesterday, user.getId());
         addBestReview(topUserReviewDtos, reviews);


### PR DESCRIPTION
무비토크에서 유저 상태 비교하는 변수가 전역으로 선언되어있어서 버그가 발생한 문제 해결
추가로 메인페이지에 사용되는 탑유저 today -> yesterday 로 파일명 변경, 변수명 변경했습니다