### PR TITLE
[BUG] 무비 서치 리뷰순, 평점 순 영화 페이징 별로 정렬된 버그 수정

### DIFF
--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/Movie.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/Movie.java
@@ -43,7 +43,7 @@ public class Movie {
 
 
     @OneToMany(mappedBy = "movie")
-    private List<Review> reviews = new ArrayList<Review>();
+    public List<Review> reviews = new ArrayList<Review>();
 
     @Builder
     public Movie(Long real_movieId, String title, String movieImg, String movieBgImg,

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/Movie.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/Movie.java
@@ -43,7 +43,7 @@ public class Movie {
 
 
     @OneToMany(mappedBy = "movie")
-    public List<Review> reviews = new ArrayList<Review>();
+    private List<Review> reviews = new ArrayList<Review>();
 
     @Builder
     public Movie(Long real_movieId, String title, String movieImg, String movieBgImg,

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/MovieRepository.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/domain/movie/MovieRepository.java
@@ -27,14 +27,8 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
     @Query("SELECT m FROM Movie m WHERE m.id = :id")
     Optional<Movie> findByMovieId(Long id);
 
-    @Query("SELECT m FROM Movie m ORDER BY (SELECT COUNT(r) FROM m.reviews r) DESC")
-    List<Movie> findMoviesWithReviewCount(Pageable pageable);
-//    @Query("SELECT m FROM Movie m LEFT JOIN m.reviews r GROUP BY m ORDER BY COUNT(r) DESC")
-//    List<Movie> findMoviesWithReviewCount(Pageable pageable);
-
-
-    @Query("select m from Movie m")
-    List<Movie> movieAllMovieByPageable(Pageable pageable);
+    @Query("SELECT m FROM Movie m ORDER BY size(m.reviews) DESC")
+    List<Movie> findMoviesWithSortedReviewCount();
 
     @Query("select m from Movie m order by m.movieDate desc")
     List<Movie> moviesByReleaseDate(Pageable pageable);

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieSearch/MovieAllSearchService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieSearch/MovieAllSearchService.java
@@ -28,12 +28,18 @@ public class MovieAllSearchService {
     @Transactional
     public ResponseEntity getMoiveSearchResponseByReviewOrder(int page) {
         try{
-            Pageable pageable = PageRequest.of(page - 1, 16);
-            List<Movie> movieList = movieRepository.movieAllMovieByPageable(pageable);
+
+            List<Movie> movieList = movieRepository.findAll();
+            movieList.sort(Comparator.comparingInt((Movie m) -> m.getReviews().size()).reversed());
 
             List<MovieSearchDto> movieSearchDtoList = new ArrayList<>();
-            int lastPage = getLastPage();
-            MovieSearchResponseDto movieSearchResponseDto = getMovieSearchResponseDto(page, movieList, movieSearchDtoList, lastPage);
+            int pageSize = 16;
+            int startIndex = (page - 1) * pageSize;
+            int endIndex = Math.min(startIndex + pageSize, movieList.size());
+            List<Movie> moviesForPage = movieList.subList(startIndex, endIndex);
+            int lastPage = (int) Math.ceil((double) movieList.size() / pageSize);
+            MovieSearchResponseDto movieSearchResponseDto = getMovieSearchResponseDto(page, moviesForPage, movieSearchDtoList, lastPage);
+
 
             return ResponseEntity.status(HttpStatus.OK).body(movieSearchResponseDto);
         }catch (Exception e){
@@ -51,7 +57,6 @@ public class MovieAllSearchService {
 
             movieSearchDtoList.add(movieSearchDto);
         }
-        Collections.sort(movieSearchDtoList, Comparator.comparingInt(MovieSearchDto::getReviewCount).reversed());
         return MovieSearchResponseDto
                 .builder().moiveSearchDtoList(movieSearchDtoList)
                 .lastPage(lastPage)
@@ -80,13 +85,9 @@ public class MovieAllSearchService {
     @Transactional
     public ResponseEntity getMoiveSearchResponseByStarScoreOrder(int page) {
         try{
-            Pageable pageable = PageRequest.of(page - 1, 16);
-            List<Movie> movieList = movieRepository.movieAllMovieByPageable(pageable);
-
+            List<Movie> movieList = movieRepository.findAll();
             List<MovieSearchDto> movieSearchDtoList = new ArrayList<>();
-            int lastPage = getLastPage();
-            for (Movie m :
-                    movieList) {
+            for (Movie m : movieList) {
                 Optional<Float> avgscore = Optional.of(starRepository.findAvgScoreByMovieIdOnMovieLog(m.getId()).orElse(0f));
                 MovieSearchDto movieSearchDto = MovieSearchDto.builder()
                         .movieId(m.getId())
@@ -98,9 +99,15 @@ public class MovieAllSearchService {
 
                 movieSearchDtoList.add(movieSearchDto);
             }
+            movieSearchDtoList.sort(Comparator.comparingDouble((MovieSearchDto m) -> m.getStarScore().doubleValue()).reversed());
 
-            Collections.sort(movieSearchDtoList, Comparator.comparingDouble(MovieSearchDto::getStarScore).reversed());
-            MovieSearchResponseDto movieSearchResponseDto = getMovieSearchResponseDto(page, movieSearchDtoList, lastPage);
+            int pageSize = 16;
+            int startIndex = (page - 1) * pageSize;
+            int endIndex = Math.min(startIndex + pageSize, movieList.size());
+
+            List<MovieSearchDto> moviesForPage = movieSearchDtoList.subList(startIndex, endIndex);
+            int lastPage = (int) Math.ceil((double) movieList.size() / pageSize);
+            MovieSearchResponseDto movieSearchResponseDto = getMovieSearchResponseDto(page, moviesForPage, lastPage);
             return ResponseEntity.status(HttpStatus.OK).body(movieSearchResponseDto);
         }catch (Exception e){
             return ResponseEntity.status(400).body("영화를 조회하는데 오류가 발생했습니다.");
@@ -108,9 +115,9 @@ public class MovieAllSearchService {
 
     }
 
-    private MovieSearchResponseDto getMovieSearchResponseDto(int page, List<MovieSearchDto> movieSearchDtoList, int lastPage) {
+    private MovieSearchResponseDto getMovieSearchResponseDto(int page, List<MovieSearchDto> moviesForPage, int lastPage) {
         return MovieSearchResponseDto
-                .builder().moiveSearchDtoList(movieSearchDtoList)
+                .builder().moiveSearchDtoList(moviesForPage)
                 .lastPage(lastPage)
                 .nowPage(page)
                 .firstPage(1)

--- a/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieSearch/MovieAllSearchService.java
+++ b/ItNovation/src/main/java/com/ItsTime/ItNovation/service/movieSearch/MovieAllSearchService.java
@@ -29,8 +29,7 @@ public class MovieAllSearchService {
     public ResponseEntity getMoiveSearchResponseByReviewOrder(int page) {
         try{
 
-            List<Movie> movieList = movieRepository.findAll();
-            movieList.sort(Comparator.comparingInt((Movie m) -> m.getReviews().size()).reversed());
+            List<Movie> movieList = movieRepository.findMoviesWithSortedReviewCount();
 
             List<MovieSearchDto> movieSearchDtoList = new ArrayList<>();
             int pageSize = 16;


### PR DESCRIPTION
### 해결상황
페이지가 요청이 들어오면 해당 페이지에서 16개의 영화를 주는데, 이 때 기존의 정렬 방식은 페이지별로 정렬이 되어 1페이지, 2페이지 정렬이 연속적이지 않음
해당 문제 쿼리와 페이징 로직 수정

### 문제 상황
리뷰 순 영화를 가져올때 정렬 후 가져와서 속도가 개선이 되었지만 
평점 순은 영화 테이블에 평점이 없고, 따로 별점 테이블에서 참조를 해야해서 모든 영화를 가져온다음 정렬하기에 속도가 조금 느림

#135 